### PR TITLE
Improve the "Python environment not configured." error message

### DIFF
--- a/src/main/java/actions/StartStopTrackingAction.java
+++ b/src/main/java/actions/StartStopTrackingAction.java
@@ -73,7 +73,13 @@ public class StartStopTrackingAction extends AnAction {
             if (!isTracking) {
                 if (config.getCheckBoxes().get(1)) {
                     if (!AvailabilityChecker.checkPythonEnvironment(config.getPythonInterpreter())) {
-                        JOptionPane.showMessageDialog(null, "Python interpreter not found. Please configure the plugin first.");
+                        JOptionPane.showMessageDialog(
+                           null,
+                           "Python interpreter not found, "+
+                           "or Python environment lacks required packages: "+
+                           "tobii_research, screeninfo, pyautogui.\n"+
+                           "Please configure the plugin first, and set up the Python environment."
+                        );
                         return;
                     }
                     if (config.getEyeTrackerDevice() != 0 && !AvailabilityChecker.checkEyeTracker(config.getPythonInterpreter())) {

--- a/src/main/java/components/ConfigDialog.java
+++ b/src/main/java/components/ConfigDialog.java
@@ -353,7 +353,11 @@ public class ConfigDialog extends DialogWrapper {
         eyeTracking.addActionListener(actionEvent -> {
             if (!pythonEnvironment) {
                 eyeTracking.setSelected(false);
-                new AlertDialog("Python environment not configured.", AllIcons.General.BalloonWarning).show();
+                new AlertDialog(
+                        "Python environment not configured, or not set up properly.\n"+
+                        "Required packages to be installed are: tobii_research, screeninfo, pyautogui.",
+                        AllIcons.General.BalloonWarning
+                ).show();
                 return;
             }
             if (!eyeTracking.isSelected()) {


### PR DESCRIPTION
The error message now explains which packages should be installed in the selected Python environment for it to pass the test.

This commit addresses issue #13 in codegrits/CodeGRITS.

*Note:* not tested.