### PR TITLE
AvailabilityChecker: Remove hard requirement on tobii_research

### DIFF
--- a/src/main/java/utils/AvailabilityChecker.java
+++ b/src/main/java/utils/AvailabilityChecker.java
@@ -19,7 +19,6 @@ public class AvailabilityChecker {
      */
     public static boolean checkPythonEnvironment(String pythonInterpreter) throws IOException, InterruptedException {
         String pythonScript = """
-                import tobii_research as tr
                 from screeninfo import get_monitors
                 import pyautogui
                 import time
@@ -41,13 +40,17 @@ public class AvailabilityChecker {
      */
     public static boolean checkEyeTracker(String pythonInterpreter) throws IOException, InterruptedException {
         String pythonScript = """
-                import tobii_research as tr
+                try:
+                    import tobii_research as tr
                 
-                found_eyetrackers = tr.find_all_eyetrackers()
-                if found_eyetrackers == ():
+                    found_eyetrackers = tr.find_all_eyetrackers()
+                    if found_eyetrackers == ():
+                        print('Not Found')
+                    else:
+                        print('Found')
+                
+                except ImportError:
                     print('Not Found')
-                else:
-                    print('Found')
                 """;
 
         String line = runPythonScript(pythonInterpreter, pythonScript);
@@ -62,13 +65,17 @@ public class AvailabilityChecker {
      */
     public static String getEyeTrackerName(String pythonInterpreter) throws IOException, InterruptedException {
         String pythonScript = """
-                import tobii_research as tr
+                try:
+                    import tobii_research as tr
                 
-                found_eyetrackers = tr.find_all_eyetrackers()
-                if found_eyetrackers == ():
+                    found_eyetrackers = tr.find_all_eyetrackers()
+                    if found_eyetrackers == ():
+                        print('Not Found')
+                    else:
+                        print(found_eyetrackers[0].device_name)
+                
+                except ImportError:
                     print('Not Found')
-                else:
-                    print(found_eyetrackers[0].device_name)
                 """;
 
         return runPythonScript(pythonInterpreter, pythonScript);


### PR DESCRIPTION
Because of how `AvailibilityChecker.checkPythonEnvironment()` was set up, the `tobii_research` module had to be installed in the selected Python environment even when one wanted to use Mouse emulation.

Installing `tobii_research` is more difficult than installing `pyautogui` because `tobii_research` requires specific Python version, namely Python 3.10 (or Python 3.8, but with more work). Switching to non-default version of Python is more work.

I have tested that mouse emulation work with these changes, but I was not able to check if tracking with Tobii still works.

----

Now [`tobii_research`][1] [module][2] does not need to be installed to be able to use mouse emulation.

[1]: https://developer.tobiipro.com/python.html
[2]: https://pypi.org/project/tobii-research/

This change removes 'import tobii_research as tr' from checkPythonEnvironment() method, and adjusts checkEyeTracker() and getEyeTrackerName() to work correctly even if tobii_research is not installed.

The problem with requiring tobii_research is that it requires specific Python version to be able to be installed: 3.8 or 3.10:

- https://www.tobii.com/products/software/applications-and-developer-kits/tobii-pro-sdk
- https://developer.tobiipro.com/tobiiprosdk/platform-and-language.html
- https://codegrits.github.io/CodeGRITS/usage-guide/#python-environment