### PR TITLE
EyeTracker: wrap call to getASTStructureElement() in runReadAction()

### DIFF
--- a/src/main/java/trackers/EyeTracker.java
+++ b/src/main/java/trackers/EyeTracker.java
@@ -9,6 +9,7 @@ import com.intellij.openapi.fileEditor.FileEditorManager;
 import com.intellij.openapi.fileEditor.FileEditorManagerEvent;
 import com.intellij.openapi.fileEditor.FileEditorManagerListener;
 import com.intellij.openapi.project.Project;
+import com.intellij.openapi.util.Computable;
 import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.psi.PsiDocumentManager;
 import com.intellij.psi.PsiElement;
@@ -250,7 +251,9 @@ public class EyeTracker implements Disposable {
                 location.setAttribute("column", String.valueOf(logicalPosition.column));
                 location.setAttribute("path", RelativePathGetter.getRelativePath(filePath, projectPath));
                 gaze.appendChild(location);
-                Element aSTStructure = getASTStructureElement(psiElement);
+                Element aSTStructure = ApplicationManager.getApplication().runReadAction(
+                        (Computable<Element>) () -> getASTStructureElement(psiElement)
+                );
                 gaze.appendChild(aSTStructure);
                 lastElement = psiElement;
 //                System.out.println(gaze.getAttribute("timestamp") + " " + System.currentTimeMillis());


### PR DESCRIPTION
This should fix the sporadic `RuntimeExceptionWithAttachments` exception in CodeGRITS plugin that happens on some projects when running eye tracker.

```
  com.intellij.openapi.diagnostic.RuntimeExceptionWithAttachments:
  Read access is allowed from inside read-action only (see Application.runReadAction());
  If you access or modify model on EDT consider wrapping your code in WriteIntentReadAction ;
  see https://jb.gg/ij-platform-threading for details
  [...]
    at trackers.EyeTracker.getASTStructureElement(EyeTracker.java:450)
    at trackers.EyeTracker.lambda$processRawData$1(EyeTracker.java:306)
```

This fix is based on the  https://stackoverflow.com/q/76809649 and the discussion in issue codegrits/CodeGRITS#17 .

----

Testing this fix shows no crashes where there were previously, but this is does not prove that the fix is correct.